### PR TITLE
Fix attachment description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## Unreleased
+### Fixed
+* Issues with `attachment_description`
+
 ## 0.0.1
 ### Other
 * Initial release

--- a/lib/wordpress/post_attachment.rb
+++ b/lib/wordpress/post_attachment.rb
@@ -31,12 +31,8 @@ module Contentful
         end
 
         def attachment_description
-          meta_arr = post.xpath('wp:postmeta').to_a
-          unless meta_arr.empty?
-            meta_arr.each do |meta|
-              return meta.at_xpath('wp:meta_value').text if meta.at_xpath('wp:meta_key').text == '_wp_attachment_image_alt'
-            end
-          end
+          alt = post.xpath('.//wp:meta_key[contains(text(), "_wp_attachment_image_alt")]').first
+          alt ? alt.parent.at_xpath('wp:meta_value').text : ''
         end
       end
     end

--- a/spec/fixtures/blog/assets/attachment_post/attachment_post_21.json
+++ b/spec/fixtures/blog/assets/attachment_post/attachment_post_21.json
@@ -1,5 +1,5 @@
 {
   "id": "attachment_post_21",
-  "description": null,
+  "description": "",
   "url": "https://szpryc.files.wordpress.com/2014/11/screen-shot-2014-11-27-at-12-34-47-pm1.png"
 }

--- a/spec/lib/wordpress/post_attachment_spec.rb
+++ b/spec/lib/wordpress/post_attachment_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require './lib/wordpress/post'
+require './lib/wordpress/blog'
+require './lib/wordpress/post_attachment'
+
+module Contentful
+  module Exporter
+    module Wordpress
+      describe PostAttachment do
+        before do
+          xml_doc = Nokogiri::XML(File.open('spec/fixtures/wordpress.xml'))
+          @items = xml_doc.search('item')
+          @post = PostAttachment.new(@items[-2], @settings)
+        end
+
+        it 'can extract the url of an attachment' do
+          url = @post.send(:attachment_url)
+
+          expect(url).to eq 'https://szpryc.files.wordpress.com/2014/11/screen-shot-2014-11-27-at-12-34-47-pm.png'
+        end
+
+        it 'can extract the id of an attachment' do
+          id = @post.send(:attachment_id)
+
+          expect(id).to eq 'attachment_post_15'
+        end
+
+        it 'can extract the description of an attachment' do
+          description = @post.send(:attachment_description)
+
+          expect(description).to eq 'MOJ_DESC'
+        end
+
+        it 'is resilient against missing wp:meta_keys' do
+          @post = PostAttachment.new(@items.last, @settings)
+          description = @post.send(:attachment_description)
+
+          expect(description).to eq ''
+        end
+
+        it 'is resilient against missing _wp_attachment_image_alt' do
+          @post = PostAttachment.new(@items[2], @settings)
+          description = @post.send(:attachment_description)
+
+          expect(description).to eq ''
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes issues with `attachment_description`:

- Do not return an array of all metadata if there is none with the key `_wp_attachment_image_alt`
- Do not return `nil` if there is no metadata at all